### PR TITLE
net: sch_generic: Disable net watchdog unconditionally

### DIFF
--- a/net/sched/sch_generic.c
+++ b/net/sched/sch_generic.c
@@ -224,6 +224,8 @@ static void dev_watchdog(unsigned long arg)
 {
 	struct net_device *dev = (struct net_device *)arg;
 
+	return;
+	
 	netif_tx_lock(dev);
 	if (!dev->watchdog_timeo)
 		return;
@@ -271,8 +273,7 @@ static void dev_watchdog(unsigned long arg)
 
 void __netdev_watchdog_up(struct net_device *dev)
 {
-	if (!dev->watchdog_timeo)
-		return;
+	return;
 
 	if (dev->netdev_ops->ndo_tx_timeout) {
 		if (dev->watchdog_timeo < 0)


### PR DESCRIPTION
This will assume all watchdog uses 0 as timeout value, which would assure
all watchdog are disabled.